### PR TITLE
Avoids parsing "taskName on browserName" when possible.

### DIFF
--- a/app/js/campaign.js
+++ b/app/js/campaign.js
@@ -51,18 +51,23 @@ angular.module("attesterCampaign", []).factory("AttesterCampaign", function () {
     };
 
     var initLeafTask = function (parentTask, taskDef) {
-        var taskName = taskDef.name;
-        var browserName = "default";
+        var taskName = taskDef.taskName;
+        var browserName = taskDef.browserName || "default";
+        if (!taskName) {
+            // backward compatibility
+            taskName = taskDef.name;
+            var splitName = /^(.+) on (.+)$/.exec(taskName);
+            if (splitName) {
+                taskName = splitName[1];
+                browserName = splitName[2];
+            }
+        }
         var taskGroup = {
             name : taskName
         };
-        if (parentTask) {
-            var sizeBeforeBrowserName = parentTask.name.length + 4;
-            if (taskName.substr(0, sizeBeforeBrowserName) == parentTask.name + " on ") {
-                // parentTask contains the same task for different browsers
-                browserName = taskName.substr(sizeBeforeBrowserName);
-                taskGroup = parentTask;
-            }
+        if (parentTask && parentTask.name == taskName) {
+            // parentTask contains the same task for different browsers
+            taskGroup = parentTask;
         }
         var lastExecution = {
             state : "waiting",
@@ -70,7 +75,7 @@ angular.module("attesterCampaign", []).factory("AttesterCampaign", function () {
             events : []
         };
         var task = {
-            name : taskName,
+            name : taskName + " on " + browserName,
             browser : getBrowser.call(this, browserName),
             taskGroup : taskGroup,
             lastExecution : lastExecution,

--- a/app/js/mergeCampaigns.js
+++ b/app/js/mergeCampaigns.js
@@ -234,6 +234,8 @@ angular.module("attesterMergeCampaigns", ["attesterCampaign", "attesterCampaigns
                             taskIdCounter++;
                             return {
                                 name : taskName + " on " + browserDefinition.name,
+                                taskName : taskName,
+                                browserName : browserDefinition.name,
                                 taskId : taskId
                             };
                         }).filter(nonNull)


### PR DESCRIPTION
The `taskName` and `browserName` properties are now used if they are available instead of parsing the `name` property (cf https://github.com/attester/attester/pull/120).

Also, merged reports now include the `taskName` and `browserName` properties.

fix #6